### PR TITLE
Add volume setting to ini

### DIFF
--- a/sm.ini
+++ b/sm.ini
@@ -43,6 +43,9 @@ LinearFiltering = 0
 [Sound]
 EnableAudio = 1
 
+# Default mixer volume
+Volume = 10
+
 # DSP frequency in samples per second (e.g. 48000, 44100, 32000, 22050, 11025)
 AudioFreq = 32000
 

--- a/sm.ini
+++ b/sm.ini
@@ -44,7 +44,7 @@ LinearFiltering = 0
 EnableAudio = 1
 
 # Default mixer volume
-Volume = 10
+Volume = 100
 
 # DSP frequency in samples per second (e.g. 48000, 44100, 32000, 22050, 11025)
 AudioFreq = 32000

--- a/src/config.c
+++ b/src/config.c
@@ -403,6 +403,9 @@ static bool HandleIniConfig(int section, const char *key, char *value) {
       return true;
     } else if (StringEqualsNoCase(key, "ResumeMSU")) {
       return ParseBool(value, &g_config.resume_msu);
+    } else if (StringEqualsNoCase(key, "Volume")) {
+      g_config.volume = (uint8)strtol(value, (char**)NULL, 10);
+      return true;
     }
   } else if (section == 3) {
     if (StringEqualsNoCase(key, "Autosave")) {

--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,7 @@ typedef struct Config {
   uint8 enable_msu;
   bool resume_msu;
   bool disable_frame_delay;
+  uint8 volume;
   uint8 msuvolume;
   uint32 features0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -357,6 +357,9 @@ int main(int argc, char** argv) {
   if (g_config.audio_samples <= 0 || ((g_config.audio_samples & (g_config.audio_samples - 1)) != 0))
     g_config.audio_samples = kDefaultSamples;
 
+  // Load the volume level from the config file
+  g_sdl_audio_mixer_volume = g_config.volume;
+
   // set up SDL
   if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER) != 0) {
     printf("Failed to init SDL: %s\n", SDL_GetError());


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
I found that I kept resetting the volume level every time I loaded up the game. So I added a config option to the ini file.

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
It shouldn't but I only tested it on linux.


### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
Change the volume setting in the ini file. The range is probably platform dependent, but SDL seems to go from 0 to 128 and it looks like windows probably ranges from 0 to 100. So the ranges aren't that different hopefully.