### PR TITLE
fix build on macos

### DIFF
--- a/src/sm_8f.c
+++ b/src/sm_8f.c
@@ -515,8 +515,8 @@ void DoorCode_SetupElevatubeFromSouth(void) {  // 0x8FE26C
 
 void DoorCode_SetupElevatubeFromNorth(void) {  // 0x8FE291
   *(uint16 *)&room_main_asm_variables[4] = 256;
-  strcpy((uint8 *)&room_main_asm_variables[2], "@");
-  strcpy((uint8 *)&room_main_asm_variables[6], " ");
+  strcpy((char *)&room_main_asm_variables[2], "@");
+  strcpy((char *)&room_main_asm_variables[6], " ");
   CallSomeSamusCode(0);
   SpawnHardcodedPlm(&unk_8FE2B1);
 }
@@ -637,8 +637,8 @@ void DoorCode_CeresElevatorShaft(void) {  // 0x8FE4E0
   reg_M7X = 128;
   reg_M7Y = 1008;
   irq_enable_mode7 = 1;
-  strcpy((uint8 *)room_main_asm_variables, "\"");
-  strcpy((uint8 *)&room_main_asm_variables[2], "<");
+  strcpy((char *)room_main_asm_variables, "\"");
+  strcpy((char *)&room_main_asm_variables[2], "<");
 }
 
 void DoorCode_CeresElevatorShaft_2(void) {  // 0x8FE513
@@ -659,7 +659,7 @@ static const uint16 kRoomCode_SpawnCeresFallingDebris_Tab[16] = {  // 0x8FE525
 void RoomCode_SpawnCeresFallingDebris(void) {
 
   if (ceres_status && (-- * (uint16 *)room_main_asm_variables, *(int16 *)room_main_asm_variables < 0)) {
-    strcpy((uint8 *)room_main_asm_variables, "\b");
+    strcpy((char *)room_main_asm_variables, "\b");
     uint16 v0 = addr_stru_869734;
     if (random_number & 0x8000)
       v0 = addr_stru_869742;
@@ -684,7 +684,7 @@ LABEL_6:
       earthquake_type = v0;
     }
   } else if (NextRandom() < 0x200u) {
-    strcpy((uint8 *)room_main_asm_variables, "*");
+    strcpy((char *)room_main_asm_variables, "*");
     v0 = 23;
     goto LABEL_6;
   }
@@ -701,7 +701,7 @@ LABEL_6:
       *(uint16 *)&room_main_asm_variables[2] = v0;
     }
   } else if (NextRandom() < 0x180u) {
-    strcpy((uint8 *)room_main_asm_variables, "*");
+    strcpy((char *)room_main_asm_variables, "*");
     v0 = 26;
     goto LABEL_6;
   }

--- a/src/sm_ad.c
+++ b/src/sm_ad.c
@@ -264,7 +264,7 @@ void MotherBrain_CalcHdma_Down_DownRight(void) {  // 0xADE216
     if (__CFADD__uint16(R20_, R24_))
       v7 = -1;
     R24_ = v7;
-    uint16 v8 = R26_ | v7 & 0xFF00;
+    int16 v8 = R26_ | v7 & 0xFF00;
     if (v8 == -1)
       v8 = 255;
     *dst++ = v8;

--- a/src/sm_ad.c
+++ b/src/sm_ad.c
@@ -264,8 +264,8 @@ void MotherBrain_CalcHdma_Down_DownRight(void) {  // 0xADE216
     if (__CFADD__uint16(R20_, R24_))
       v7 = -1;
     R24_ = v7;
-    int16 v8 = R26_ | v7 & 0xFF00;
-    if (v8 == -1)
+    uint16 v8 = R26_ | v7 & 0xFF00;
+    if (v8 == 0xFFFF)
       v8 = 255;
     *dst++ = v8;
     ++mbn_var_3D;


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
build on macos was failing due to -Wpointer-sign -Werror 

previously:

```
make
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/config.c -o src/config.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/glsl_shader.c -o src/glsl_shader.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/main.c -o src/main.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/opengl.c -o src/opengl.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_80.c -o src/sm_80.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_81.c -o src/sm_81.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_82.c -o src/sm_82.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_84.c -o src/sm_84.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_85.c -o src/sm_85.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_86.c -o src/sm_86.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_87.c -o src/sm_87.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_88.c -o src/sm_88.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_89.c -o src/sm_89.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_8b.c -o src/sm_8b.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_8d.c -o src/sm_8d.o
cc -c -O2 -fno-strict-aliasing -Werror  -I/opt/local/include/SDL2 -D_THREAD_SAFE -DSYSTEM_VOLUME_MIXER_AVAILABLE=0 -I. src/sm_8f.c -o src/sm_8f.o
src/sm_8f.c:518:10: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
  strcpy((uint8 *)&room_main_asm_variables[2], "@");
  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:519:10: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
  strcpy((uint8 *)&room_main_asm_variables[6], " ");
  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:640:10: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
  strcpy((uint8 *)room_main_asm_variables, "\"");
  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:641:10: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
  strcpy((uint8 *)&room_main_asm_variables[2], "<");
  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:662:12: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
    strcpy((uint8 *)room_main_asm_variables, "\b");
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:687:12: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
    strcpy((uint8 *)room_main_asm_variables, "*");
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
src/sm_8f.c:704:12: error: passing 'uint8 *' (aka 'unsigned char *') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
    strcpy((uint8 *)room_main_asm_variables, "*");
    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_string.h:84:27: note: expanded from macro 'strcpy'
                __builtin___strcpy_chk (dest, __VA_ARGS__, __darwin_obsz (dest))
                                        ^~~~
7 errors generated.
make: *** [src/sm_8f.o] Error 1
```

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
probably not

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
shouldn't be functionally any different
