### PR TITLE
guard #pragma warning on non-MSVC compilers

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -1,7 +1,9 @@
 #ifndef SM_TYPES_H_
 #define SM_TYPES_H_
 
+#ifdef _MSC_VER
 #pragma warning(disable: 4244)
+#endif
 
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
### Description
This pragma is only recognized by MSVC

### Will this Pull Request break anything? 
No

### Suggested Testing Steps
Compile with `-Wunknown-pragmas` and observe this error is gone.
