### PR TITLE
Added QoL feature to exit with keycombo(keyboard) or button combo (co…

### DIFF
--- a/sm.ini
+++ b/sm.ini
@@ -80,6 +80,7 @@ WindowSmaller = Ctrl+Down
 
 VolumeUp = Shift+=
 VolumeDown = Shift+-
+Quit = Shift+Return
 
 Load =      F1,     F2,     F3,     F4,     F5,     F6,     F7,     F8,     F9,     F10
 Save = Shift+F1,Shift+F2,Shift+F3,Shift+F4,Shift+F5,Shift+F6,Shift+F7,Shift+F8,Shift+F9,Shift+F10
@@ -92,4 +93,4 @@ ReplayRef = Ctrl+1,Ctrl+2,Ctrl+3,Ctrl+4,Ctrl+5,Ctrl+6,Ctrl+7,Ctrl+8,Ctrl+9,Ctrl+
 # Any keys used in KeyMap can be used also in this section.
 # The shoulder button is called L1/Lb and L2, and the thumbstick button is called L3
 Controls = DpadUp, DpadDown, DpadLeft, DpadRight, Back, Start, B, A, Y, X, Lb, Rb
-
+Quit = Start+Back

--- a/src/config.c
+++ b/src/config.c
@@ -40,7 +40,7 @@ static const uint16 kDefaultKbdControls[kKeys_Total] = {
   // ClearKeyLog, StopReplay, Fullscreen, Reset, Pause, PauseDimmed, Turbo, ReplayTurbo, WindowBigger, WindowSmaller, DisplayPerf, ToggleRenderer
   _(SDLK_k), _(SDLK_l), A(SDLK_RETURN), C(SDLK_r), S(SDLK_p), _(SDLK_p), _(SDLK_TAB), _(SDLK_t), N, N, _(SDLK_f), _(SDLK_r),
   // VolumeUp VolumeDown
-  0, 0,
+  0, 0, N,
 };
 #undef _
 #undef A
@@ -60,7 +60,7 @@ static const KeyNameId kKeyNameId[] = {
   M(Controls), M(Load), M(Save), M(Replay), M(LoadRef), M(ReplayRef),
   S(CheatLife), S(CheatJump), S(ToggleWhichFrame),
   S(ClearKeyLog), S(StopReplay), S(Fullscreen), S(Reset),
-  S(Pause), S(PauseDimmed), S(Turbo), S(ReplayTurbo), S(WindowBigger), S(WindowSmaller), S(VolumeUp), S(VolumeDown), S(DisplayPerf), S(ToggleRenderer),
+  S(Pause), S(PauseDimmed), S(Turbo), S(ReplayTurbo), S(WindowBigger), S(WindowSmaller), S(VolumeUp), S(VolumeDown), S(DisplayPerf), S(ToggleRenderer), S(Quit),
 };
 #undef S
 #undef M

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,7 @@ enum {
   kKeys_ToggleRenderer,
   kKeys_VolumeUp,
   kKeys_VolumeDown,
+  kKeys_Quit,
   kKeys_Total,
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -659,6 +659,10 @@ static void HandleCommand(uint32 j, bool pressed) {
     case kKeys_Reset:
       RtlReset(1);
       break;
+    case kKeys_Quit:
+      SDL_Quit();
+      exit(0);
+      break;
     case kKeys_Pause: g_paused = !g_paused; break;
     case kKeys_PauseDimmed:
       g_paused = !g_paused;


### PR DESCRIPTION
Added small QoL feature to allow exiting without use of keyboard & mouse. Right Shift + Return (keyboard) or Start + Back (gamepad). Configurable in the ini. Mainly for use on a system without connected keyboard & mouse.
